### PR TITLE
fix TypeError in exception

### DIFF
--- a/bin/dns_lookup.py
+++ b/bin/dns_lookup.py
@@ -56,7 +56,7 @@ def dns_lookup(query, record_type = 'A', server = None):
 		sys.stderr.write("Does not resolve: " + str(query) + "\n")
 		return ["Error:NXDOMAIN"]
 	except BaseException as e:
-		sys.stderr.write("query=" + query + " error=\"" + str(e) + "\"\n")
+		sys.stderr.write("query=" + str(query) + " error=\"" + str(e) + "\"\n")
 		return ["Error:"+str(e)]
 
 def main():


### PR DESCRIPTION
Hi, 
I am testing Add-On for DNS Lookup for Splunk, and it looked almost working fine. I found Splunk search is faild in case performing PTR query and timeout occured.
I investigated dns_lookup.py and found that TypeError occured because 'query' has not been converted to string. I changed the code to convert 'query' to string, Splunk search looked working fine.  I would appreciate it if you consider the pullreq. 
Thank you for developing the Add-on!

Small example to reproduce the exception:

```

$ echo -e "hostname\n1.1.1.1" | python3 dns_lookup.py -server 192.168.100.100 -type ptr
hostname,ip,dns_error
1.1.1.1
Traceback (most recent call last):
  File "/opt/splunk/etc/apps/TA-dnslookup/bin/dns_lookup.py", line 36, in dns_lookup
    answer = resolver.resolve(query, record_type)
  File "/opt/splunk/etc/apps/TA-dnslookup/bin/dns/resolver.py", line 1176, in resolve
    timeout = self._compute_timeout(start, lifetime)
  File "/opt/splunk/etc/apps/TA-dnslookup/bin/dns/resolver.py", line 997, in _compute_timeout
    raise Timeout(timeout=duration)
dns.exception.Timeout: The DNS operation timed out after 2.6018104553222656 seconds

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/splunk/etc/apps/TA-dnslookup/bin/dns_lookup.py", line 137, in <module>
    main()
  File "/opt/splunk/etc/apps/TA-dnslookup/bin/dns_lookup.py", line 107, in main
    answers = dns_lookup(result[in_field], record_type=args.record_type, server=args.server)
  File "/opt/splunk/etc/apps/TA-dnslookup/bin/dns_lookup.py", line 59, in dns_lookup
    sys.stderr.write("query=" + query + " error=\"" + str(e) + "\"\n")
TypeError: can only concatenate str (not "Name") to str
```